### PR TITLE
feat: dockerfile set go china source

### DIFF
--- a/build/docker/auth/Dockerfile
+++ b/build/docker/auth/Dockerfile
@@ -2,6 +2,10 @@
 FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
 ARG TARGETARCH
 ARG TARGETOS
+# 启用 Go Modules 功能
+RUN go env -w GO111MODULE=on
+# go 设置国内源
+RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.mod

--- a/build/docker/blog/Dockerfile
+++ b/build/docker/blog/Dockerfile
@@ -2,6 +2,10 @@
 FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
 ARG TARGETARCH
 ARG TARGETOS
+# 启用 Go Modules 功能
+RUN go env -w GO111MODULE=on
+# go 设置国内源
+RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.mod

--- a/build/docker/comment/Dockerfile
+++ b/build/docker/comment/Dockerfile
@@ -2,6 +2,10 @@
 FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
 ARG TARGETARCH
 ARG TARGETOS
+# 启用 Go Modules 功能
+RUN go env -w GO111MODULE=on
+# go 设置国内源
+RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.mod

--- a/build/docker/post/Dockerfile
+++ b/build/docker/post/Dockerfile
@@ -2,6 +2,10 @@
 FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
 ARG TARGETARCH
 ARG TARGETOS
+# 启用 Go Modules 功能
+RUN go env -w GO111MODULE=on
+# go 设置国内源
+RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.mod

--- a/build/docker/user/Dockerfile
+++ b/build/docker/user/Dockerfile
@@ -2,6 +2,10 @@
 FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
 ARG TARGETARCH
 ARG TARGETOS
+# 启用 Go Modules 功能
+RUN go env -w GO111MODULE=on
+# go 设置国内源
+RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 WORKDIR /workspace
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.mod


### PR DESCRIPTION
我这边 dockerfile 不给国内 源 下载 很慢 ，甚至会失败 …… 
另外问下 这些个变量 是 干什么的？ 
![image](https://user-images.githubusercontent.com/39295458/153850023-0353c5bf-957c-4d7e-a8de-86d4598c8ad5.png)
我这里 不删除的话 make docker-build 会报 错
```
$ make docker-build
docker build -t blog/blog-server:latest -f ./build/docker/blog/Dockerfile .
Sending build context to Docker daemon  19.03MB
Step 1/21 : FROM --platform=$TARGETPLATFORM golang:1.17-alpine as builder
failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument
make: *** [Makefile:85: docker-build] Error 1

```
第一步都过不去…… 我的环境是 debian 10.0  搭了 k8s 和istio ,另外我在 archlinux 下也是这个表现  